### PR TITLE
Use PyPI pip 26.1+ in user dir for pip CVE workaround

### DIFF
--- a/Dockerfile.python-base
+++ b/Dockerfile.python-base
@@ -1,14 +1,16 @@
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31 AS builder
 
-RUN apk update && apk add --no-cache --upgrade python3 py3-pip
+# pip CVE workaround: temp PyPI pip 26.1+ in user dir; restore "py3-pip" when Wolfi bumps
+RUN apk update && apk add --no-cache --upgrade python3
 
 # local install to /home/nonroot/.local/bin
 USER nonroot
 ENV POETRY_HOME=/home/nonroot \
-    PATH=$PATH:/home/nonroot/.local/bin \
+    PATH=/home/nonroot/.local/bin:$PATH \
     PYTHONPATH=/home/nonroot/.local/lib/python3/site-packages
 
-RUN python3 -m pip install --no-cache-dir --upgrade --user -v poetry cryptography virtualenv 
+RUN python3 -m ensurepip --user --upgrade && \
+    python3 -m pip install --no-cache-dir --upgrade --user -v 'pip>=26.1' poetry cryptography virtualenv
 
 # Poetry sets default max workers to num of cpu-cores + 4, but pip max connection pool
 # is set at 10 and will discard any above that when installing dependencies
@@ -28,7 +30,9 @@ echo "pip=$(pip3 --version 2>&1 | awk -F' ' '{print $2}' | tr -d '\n')" >> /tmp/
 echo "poetry=$(poetry --version 2>&1 | awk -F 'version |\\)' '{print $2}' | sed 's/)$//')" >> /tmp/versions.txt
 
 USER root
-RUN apk del libcurl-openssl4 curl
+# pip CVE workaround: drop py3-pip-wheel artifacts (transitive dep) so Trivy reads only user-local pip 26.1+
+RUN apk del libcurl-openssl4 curl && \
+    rm -f /usr/share/python-wheels/pip-*.whl /var/lib/db/sbom/py3-pip-wheel-*.spdx.json
 
 USER nonroot
 RUN python3 --version


### PR DESCRIPTION
Wolfi has not yet bumped `py3-pip-wheel` to a fixed version. Workaround: install pip 26.1+ from PyPI into the nonroot user dir; remove the apk pip wheel and SBOM stub so Trivy reads only the upgraded version.

Verified locally - amd64 and arm64: pip 26.1.1 in /home/nonroot/.local; 0 MEDIUM+ Trivy findings (--ignore-unfixed).

**Revert when Wolfi bumps py3-pip-wheel**: restore `py3-pip` in apk add; drop ensurepip + `pip>=26.1`; drop the wheel/SBOM rm from the root cleanup step.