### PR TITLE
Fix nodejs-base structure test + docs for npm 12 / node 24.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Images are considered hardened when they do not contain fixable-today CVE vulner
 ## Current Language Versions
 
 * **Go**: 1.26.x (from chainguard/go:latest)
-* **Node.js**: 24.6.x with npm 11.5.x (from wolfi-base with nodejs/npm packages)
+* **Node.js**: 24.18.x with npm 12.0.x (from wolfi-base with nodejs/npm packages)
 * **Python**: 3.13.x (from wolfi-base with python3 package)
 * **OpenJDK**: 17.x with Maven 3.9.8 (from wolfi-base with openjdk-17 package)
 * **Wolfi Base**: Latest minimal Linux distribution
@@ -67,11 +67,11 @@ Images are considered hardened when they do not contain fixable-today CVE vulner
 
 ### Recommended Version Pinning
 
-The images are tagged with [Semantic Versioning](https://semver.org/) and also with the installed language's major (i.e. `python-base:3`, `nodejs-base:24`) and major + minor (i.e. `python-base:3.13`, `go-base:1.26`, `nodejs-base:24.6`) versions (currently implemented for Python, Node.js, OpenJDK, and Go).
+The images are tagged with [Semantic Versioning](https://semver.org/) and also with the installed language's major (i.e. `python-base:3`, `nodejs-base:24`) and major + minor (i.e. `python-base:3.13`, `go-base:1.26`, `nodejs-base:24.18`) versions (currently implemented for Python, Node.js, OpenJDK, and Go).
 
-If you want to ensure that your image's installed language is not updated to a potentially non-backwards-compatible version, you can pin the version of the image you are using to the specific version of the language you want - i.e. `python-base:3.13` or `nodejs-base:24.6`.
+If you want to ensure that your image's installed language is not updated to a potentially non-backwards-compatible version, you can pin the version of the image you are using to the specific version of the language you want - i.e. `python-base:3.13` or `nodejs-base:24.18`.
 
-Note, however, that due to the limitations of our using Chainguard's free tier, we can only keep the latest wolfi-base image up-to-date, so once wolfi-base moves to python 3.14 or nodejs 25 for example, the python-base:3.13 or nodejs-base:24.6 will no longer be automatically patched by our workflows.
+Note, however, that due to the limitations of our using Chainguard's free tier, we can only keep the latest wolfi-base image up-to-date, so once wolfi-base moves to python 3.14 or nodejs 25 for example, the python-base:3.13 or nodejs-base:24.18 will no longer be automatically patched by our workflows.
 
 On the other hand, pinning your image to `python-base:3` or `nodejs-base:24` for example, allows you to receive all security updates within that major version, but it will also force you to upgrade to the next minor version whenever wolfi-base is updated to that version of the language.
 

--- a/tests/container-structure/nodejs-base.yaml
+++ b/tests/container-structure/nodejs-base.yaml
@@ -10,7 +10,7 @@ commandTests:
   - name: "NPM is available"
     command: "npm"
     args: ["--version"]
-    expectedOutput: ["11."]
+    expectedOutput: ["12."]
     
   - name: "User is nobody"
     command: "id"


### PR DESCRIPTION
The wolfi-base digest bump in #692 moved nodejs-base to **node v24.18.0** with **npm 12.0.0**, which broke the `publish_image` structure test (asserted npm `11.`) and left the README version references stale. This is what failed the release build on `release/nodejs-base/v1.1.400`.

## Changes
- `tests/container-structure/nodejs-base.yaml`: npm `expectedOutput` `11.` -> `12.`
- `README.md`: Node.js `24.6.x`/npm `11.5.x` -> `24.18.x`/npm `12.0.x`; minor-pin examples `24.6` -> `24.18`

## Verification (local, both arches)
| arch | node | npm | container-structure-test |
| --- | --- | --- | --- |
| linux/amd64 | v24.18.0 | 12.0.0 | 7/7 pass |
| linux/arm64 | v24.18.0 | 12.0.0 | 7/7 pass |