### PR TITLE
Fix daily rebuild so apk-only CVE fixes get patched (python-base HIGH CVE)

### DIFF
--- a/.github/workflows/daily-scan-and-rebuild.yml
+++ b/.github/workflows/daily-scan-and-rebuild.yml
@@ -34,7 +34,7 @@ jobs:
             exit 1
           fi
           echo "Discovered image base names: $BASE_NAMES"
-          echo "IMAGE_BASE_NAMES=$BASE_NAMES" >> $GITHUB_ENV
+          echo "IMAGE_BASE_NAMES=$BASE_NAMES" >> "$GITHUB_ENV"
 
       - name: Setup Docker environment
         uses: ./.github/actions/setup-docker
@@ -87,73 +87,50 @@ jobs:
               if trivy image \
                 --ignore-unfixed \
                 --exit-code 1 \
-                --severity ${{ env.TRIGGER_SEVERITIES }} \
+                --severity "${{ env.TRIGGER_SEVERITIES }}" \
                 --format table \
                 "$full_image_tag"; then
-                echo "✅ No fixable vulnerabilities found in $full_image_tag"
+                echo "[ok] No fixable vulnerabilities found in $full_image_tag"
               else
                 scan_exit_code=$?
                 if [ $scan_exit_code -eq 1 ]; then
-                  echo "⚠️  Fixable vulnerabilities found in $full_image_tag"
+                  echo "[warn] Fixable vulnerabilities found in $full_image_tag"
                   found_fixable_vulns_for_base=true
                 else
-                  echo "❌ Trivy scan failed for $full_image_tag (exit code: $scan_exit_code)"
+                  echo "[fail] Trivy scan failed for $full_image_tag (exit code: $scan_exit_code)"
                   # Continue processing other platforms
                 fi
               fi
             done # End platform loop
 
-            # Check if we need to rebuild based on vulnerabilities + base image freshness
+            # Rebuild whenever fixable vulnerabilities are found. Fixes often ship as apk
+            # package updates (e.g. python-3.13 r0 -> r2) with no base image digest change,
+            # so we must NOT gate the rebuild on base image freshness - the build pulls the
+            # latest packages via apk regardless. Base image freshness is logged for context.
             if [ "$found_fixable_vulns_for_base" = true ]; then
-              echo "🔍 Vulnerabilities found for $base_name. Checking base image freshness..."
+              echo "[rebuild] Fixable vulnerabilities found for $base_name. Adding to rebuild list."
+              needs_rebuild_list="${needs_rebuild_list} ${base_name}"
+              rebuild_reason="Fixable vulnerabilities found; rebuilding to pick up latest packages."
+
+              # Informational: report base image freshness (does not gate the rebuild)
               dockerfile="Dockerfile.$base_name"
-              if [ ! -f "$dockerfile" ]; then
-                echo "::error::Dockerfile $dockerfile not found. Cannot check base image. Skipping rebuild trigger for $base_name."
-                continue # Skip to next base_name
-              fi
-
-              # Extract base image information from Dockerfile
-              from_line=$(grep -i '^FROM' "$dockerfile" | head -n 1)
-              echo "Parsing FROM line: $from_line"
-
-              # Extract image name and SHA from FROM line
-              from_image_name=$(echo "$from_line" | sed -E -n 's/^FROM\s+([^@]+)@sha256:.*/\1/p')
-              current_sha_with_prefix=$(echo "$from_line" | sed -E -n 's/.*(@sha256:[a-f0-9]{64}).*/\1/p')
-
-              # Trim whitespace
-              from_image_name=$(echo "$from_image_name" | xargs)
-
-              if [ -n "$from_image_name" ] && [ -n "$current_sha_with_prefix" ]; then
-                current_sha_digest="${current_sha_with_prefix#@}" # Remove the '@' prefix
-                echo "Dockerfile uses base image: [$from_image_name] with SHA: [$current_sha_digest]"
-
-                echo "Querying registry for latest digest of [$from_image_name]..."
-                if latest_sha_digest=$(docker manifest inspect "$from_image_name" | jq -r 'if type == "array" then .[0].digest else (.manifests[0].digest // .config.digest // .digest) end // empty'); then
-                  if [ -n "$latest_sha_digest" ]; then
-                    echo "Latest digest found: [$latest_sha_digest]"
-                    if [ "$current_sha_digest" != "$latest_sha_digest" ]; then
-                      echo "🔄 Base image has updates: $latest_sha_digest vs $current_sha_digest"
-                      echo "Adding '$base_name' to rebuild list (vulnerabilities found + outdated base image)"
-                      needs_rebuild_list="${needs_rebuild_list} ${base_name}"
-                      rebuild_reason="Fixable vulnerabilities found and base image $from_image_name has updates."
+              if [ -f "$dockerfile" ]; then
+                from_line=$(grep -i '^FROM' "$dockerfile" | head -n 1)
+                from_image_name=$(echo "$from_line" | sed -E -n 's/^FROM\s+([^@]+)@sha256:.*/\1/p' | xargs)
+                current_sha_with_prefix=$(echo "$from_line" | sed -E -n 's/.*(@sha256:[a-f0-9]{64}).*/\1/p')
+                if [ -n "$from_image_name" ] && [ -n "$current_sha_with_prefix" ]; then
+                  current_sha_digest="${current_sha_with_prefix#@}"
+                  if latest_sha_digest=$(docker manifest inspect "$from_image_name" 2>/dev/null | jq -r 'if type == "array" then .[0].digest else (.manifests[0].digest // .config.digest // .digest) end // empty'); then
+                    if [ -n "$latest_sha_digest" ] && [ "$current_sha_digest" != "$latest_sha_digest" ]; then
+                      echo "[info] Base image [$from_image_name] also has a newer digest available ($latest_sha_digest)."
                     else
-                      echo "✅ Base image [$from_image_name] is up-to-date. Skipping rebuild despite vulnerabilities."
-                      rebuild_reason="Fixable vulnerabilities found, but base image $from_image_name is already up-to-date."
+                      echo "[info] Base image [$from_image_name] is current; fix expected via apk package update."
                     fi
-                  else
-                    echo "::warning::Could not extract latest digest from manifest for [$from_image_name]. Skipping rebuild."
-                    rebuild_reason="Fixable vulnerabilities found, but could not determine latest base image digest."
                   fi
-                else
-                  echo "::warning::Failed to inspect manifest for base image [$from_image_name]. Skipping rebuild."
-                  rebuild_reason="Fixable vulnerabilities found, but failed to inspect base image $from_image_name."
                 fi
-              else
-                echo "::error::Could not parse FROM line components in $dockerfile. Line was: '$from_line'"
-                rebuild_reason="Fixable vulnerabilities found, but could not parse FROM line in $dockerfile."
               fi
             else
-              echo "✅ No fixable vulnerabilities found for $base_name"
+              echo "[ok] No fixable vulnerabilities found for $base_name"
               rebuild_reason="No fixable vulnerabilities found."
             fi
             echo "Decision for $base_name: $rebuild_reason"
@@ -163,14 +140,14 @@ jobs:
           unique_needs_rebuild=$(echo "$needs_rebuild_list" | xargs -n1 | sort -u | xargs)
 
           if [ -z "$unique_needs_rebuild" ]; then
-            echo "✅ No images require rebuilding based on vulnerability scans and base image freshness checks."
-            echo "triggered_rebuilds=false" >> $GITHUB_OUTPUT
+            echo "[ok] No images require rebuilding based on vulnerability scans and base image freshness checks."
+            echo "triggered_rebuilds=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "🚀 Triggering rebuilds for: $unique_needs_rebuild"
-          echo "triggered_rebuilds=true" >> $GITHUB_OUTPUT
-          echo "rebuild_list=$unique_needs_rebuild" >> $GITHUB_OUTPUT
+          echo "[trigger] Triggering rebuilds for: $unique_needs_rebuild"
+          echo "triggered_rebuilds=true" >> "$GITHUB_OUTPUT"
+          echo "rebuild_list=$unique_needs_rebuild" >> "$GITHUB_OUTPUT"
 
           # Configure git for creating tags
           git config user.name "github-actions[bot]"
@@ -196,12 +173,13 @@ jobs:
             fi
 
             # Increment patch version for clean semver
-            version_part_clean=$(echo "$version_part" | sed 's/\+.*//')
+            version_part_clean="${version_part%%+*}"
             # Extract current version numbers (e.g., v1.2.3 -> 1 2 3)
-            version_nums=$(echo "$version_part_clean" | sed 's/^v//' | tr '.' ' ')
-            major=$(echo $version_nums | cut -d' ' -f1)
-            minor=$(echo $version_nums | cut -d' ' -f2)
-            patch=$(echo $version_nums | cut -d' ' -f3)
+            version_nums="${version_part_clean#v}"
+            version_nums="${version_nums//./ }"
+            major=$(echo "$version_nums" | cut -d' ' -f1)
+            minor=$(echo "$version_nums" | cut -d' ' -f2)
+            patch=$(echo "$version_nums" | cut -d' ' -f3)
             
             # Increment patch version
             new_patch=$((patch + 1))
@@ -211,7 +189,7 @@ jobs:
             echo "Creating and pushing rebuild tag: $new_tag"
             git tag "$new_tag"
             git push origin "$new_tag"
-            echo "✅ Rebuild triggered for $base_name by pushing tag $new_tag"
+            echo "[ok] Rebuild triggered for $base_name by pushing tag $new_tag"
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-base-images.yml
+++ b/.github/workflows/publish-base-images.yml
@@ -120,6 +120,8 @@ jobs:
           file: Dockerfile.${{ steps.context.outputs.image-base-name }}
           platforms: ${{ matrix.platform }}
           load: true
+          build-args: |
+            CACHEBUST=${{ github.run_id }}-${{ github.run_attempt }}
           tags: ${{ github.repository }}/${{ steps.context.outputs.image-name }}:test
           cache-from: type=gha,scope=${{ github.repository }}-${{ steps.context.outputs.image-name }}
           cache-to: type=gha,mode=max,scope=${{ github.repository }}-${{ steps.context.outputs.image-name }}
@@ -591,6 +593,8 @@ jobs:
           file: Dockerfile.${{ steps.context.outputs.image-base-name }}
           push: true
           platforms: ${{ matrix.platform }}
+          build-args: |
+            CACHEBUST=${{ github.run_id }}-${{ github.run_attempt }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ github.repository }}-${{ steps.context.outputs.image-name }}

--- a/Dockerfile.nginx-base
+++ b/Dockerfile.nginx-base
@@ -4,8 +4,10 @@ FROM cgr.dev/chainguard/nginx:latest-dev@sha256:05dcc7f5e6ba9de99aefb5c08654e51b
 # Switching to root user for package installation
 USER root
 
+# CACHEBUST busts the apk layer cache each run so daily rebuilds pick up package updates
+ARG CACHEBUST=unset
 # Installing required packages for building NGINX
-RUN apk update && apk --no-cache add -u perl wget build-base pcre-dev zlib-dev curl openssl-dev
+RUN echo "cachebust=${CACHEBUST}" && apk update && apk --no-cache add -u perl wget build-base pcre-dev zlib-dev curl openssl-dev
 
 # Define NGINX and additional compatible module versions
 # https://github.com/openresty/headers-more-nginx-module/?tab=readme-ov-file#compatibility

--- a/Dockerfile.nodejs-base
+++ b/Dockerfile.nodejs-base
@@ -1,8 +1,10 @@
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795 AS builder
 
 ARG NODE_VERSION='nodejs~=24'
+# CACHEBUST busts the apk layer cache each run so daily rebuilds pick up package updates
+ARG CACHEBUST=unset
 # Install Node.js, npm and Yarn
-RUN apk add --no-cache ${NODE_VERSION} yarn npm
+RUN echo "cachebust=${CACHEBUST}" && apk add --no-cache ${NODE_VERSION} yarn npm
 
 # Extract Node.js version and save to file
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]

--- a/Dockerfile.openjdk17-base
+++ b/Dockerfile.openjdk17-base
@@ -4,9 +4,11 @@ FROM cgr.dev/chainguard/wolfi-base:latest@sha256:02dab76bd852a70556b5b2002195c8a
 ARG MAVEN_VERSION='maven~=3.9'
 ARG OPENJDK_PACKAGE=openjdk-17
 
+# CACHEBUST busts the apk layer cache each run so daily rebuilds pick up package updates
+ARG CACHEBUST=unset
 # Install necessary packages, common build tools, create non-root user, and perform cleanup
 # --upgrade ensures latest packages for security (including dependencies)
-RUN apk add --no-cache \
+RUN echo "cachebust=${CACHEBUST}" && apk add --no-cache \
         # Core Java/Maven stack
         ${OPENJDK_PACKAGE} \
         ${MAVEN_VERSION} \

--- a/Dockerfile.python-base
+++ b/Dockerfile.python-base
@@ -1,6 +1,8 @@
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795 AS builder
 
-RUN apk update && apk add --no-cache --upgrade python3 py3-pip
+# CACHEBUST busts the apk layer cache each run so daily rebuilds pick up package updates
+ARG CACHEBUST=unset
+RUN echo "cachebust=${CACHEBUST}" && apk update && apk add --no-cache --upgrade python3 py3-pip
 
 # local install to /home/nonroot/.local/bin
 USER nonroot


### PR DESCRIPTION
## Problem

The published `python-base` image shipped `python-3.13 3.13.14-r0` with a fixable **HIGH** CVE (`CVE-2026-11940`, tarfile.extractall filter bypass; fixed in `3.13.14-r2`), and the daily rebuild never applied it. Root cause is two compounding bugs:

1. **daily-scan rebuild gate** (`daily-scan-and-rebuild.yml`): only rebuilt when a fixable vuln was found **AND** the base image had a newer digest. apk package fixes (`r0 -> r2`) ship with no base-image digest change, so the job logged *"base image up-to-date, skipping rebuild despite vulnerabilities"* and left the CVE unpatched.
2. **gha build cache** (`publish-base-images.yml`, `cache-from/to: type=gha,mode=max`): reused the cached `RUN apk add --upgrade` layer, so even a triggered rebuild produced `r0`. `pull: true` only refreshes the base image, not that layer.

## Changes

- **daily-scan-and-rebuild.yml**: rebuild whenever fixable vulns are found, regardless of base-image freshness (freshness is now logged only). Also quoted shell expansions + replaced `sed` with parameter expansion (shellcheck SC2086/SC2001) and replaced log emoji with ASCII tags.
- **CACHEBUST**: added `ARG CACHEBUST` before the `apk` step in `python-base`, `nodejs-base`, `nginx-base`, `openjdk17-base`, fed `CACHEBUST=${{ github.run_id }}-${{ github.run_attempt }}` via `build-args` on both build-push-action steps, so the package layer rebuilds each run.

## Verification (local, linux/amd64)

Fresh `docker build --pull --no-cache --build-arg CACHEBUST=...` of `Dockerfile.python-base`:

- installs `python-3.13 3.13.14-r2`
- `trivy image --severity MEDIUM,HIGH,CRITICAL --ignore-unfixed` -> **0 findings** (CVE-2026-11940 cleared)

Security battery clean: gitleaks, trufflehog (verified), non-ASCII (byte-mode), zizmor introduces **0 new** findings vs main.

## Follow-ups (separate PRs, tracked)

- #708 - harden workflows (38 pre-existing zizmor findings)
- #709 - python-base pip CVEs (msgpack, setuptools)

A force-rebuild/publish of `python-base` should wait until #709 lands, otherwise the publish scan still fails on msgpack/setuptools.
